### PR TITLE
Fix documentation wrong tag in example

### DIFF
--- a/midpoint/reference/concepts/iteration/unique-midpoint-user-name.adoc
+++ b/midpoint/reference/concepts/iteration/unique-midpoint-user-name.adoc
@@ -137,7 +137,7 @@ In the following example, iterator is increasing sequentially and zero-padded:
 ----
 <objectTemplate>
 . . .
-    <iteration>
+    <iterationSpecification>
         <maxIterations>999</maxIterations>
         <tokenExpression>
             <script>
@@ -150,7 +150,7 @@ In the following example, iterator is increasing sequentially and zero-padded:
                 </code>
             </script>
         </tokenExpression>
-    </iteration>
+    </iterationSpecification>
 . . .
 </objectTemplate>
 ----
@@ -174,7 +174,7 @@ In the following example, iterator is random (1-999 to have at most three digits
 ----
 <objectTemplate>
 . . .
-    <iteration>
+    <iterationSpecification>
         <maxIterations>999</maxIterations>
         <tokenExpression>
             <script>
@@ -188,7 +188,7 @@ In the following example, iterator is random (1-999 to have at most three digits
                 </code>
             </script>
         </tokenExpression>
-    </iteration>
+    </iterationSpecification>
 . . .
 </objectTemplate>
 ----


### PR DESCRIPTION
The example XML shows `<iteration>` as the tag to define a rule for the toke computation. This has been corrected to `<iterationSpecification>` which is also done like this in the example: [object-template-user.xml](https://github.com/Evolveum/midpoint-samples/blob/b3168318cb292b4bf620772f41a22276ae1b5ddd/samples/book/8/object-template-user.xml)