### PR TITLE
correct the github path for samples of ScriptedSQL

### DIFF
--- a/connectors/resources/sql.adoc
+++ b/connectors/resources/sql.adoc
@@ -248,4 +248,4 @@ Upgrading the JDBC driver to 9.3 seems to fix the issue.
 
 === Resource Sample
 
-See resource samples and Groovy implementation scripts in link:https://github.com/Evolveum/midpoint/tree/master/samples/resources/scriptedsql[Git samples directory for ScriptedSQL connector (master)].
+See resource samples and Groovy implementation scripts in link:https://github.com/Evolveum/midpoint-samples/tree/master/samples/resources/scriptedsql[Git samples directory for ScriptedSQL connector (master)].


### PR DESCRIPTION
At the bottom of the page there is a link to samples of the scripted sql  connector. The path fragment /midpoint/ should be /midpoint-samples/. The current URL yields a 404.

     hazelton@internet2.edu 