### PR TITLE
Fix outdated call of createModificationAdd method

### DIFF
--- a/midpoint/reference/concepts/clockwork/scripting-hooks.adoc
+++ b/midpoint/reference/concepts/clockwork/scripting-hooks.adoc
@@ -59,7 +59,7 @@ The following code block provides an example of Groovy scripting hook.
                                 orgTarget.setOid(org.getOid());
                                 orgTarget.setType(OrgType.COMPLEX_TYPE);
                                 assignment.setTargetRef(orgTarget);
-                                assignmentDelta = ContainerDelta.createModificationAdd(UserType.F_ASSIGNMENT, UserType.class, prismContext, assignment);
+                                assignmentDelta = prismContext.deltaFactory().container().createModificationAdd(UserType.F_ASSIGNMENT, UserType.class, assignment);
                                 modelContext.getFocusContext().swallowToPrimaryDelta(assignmentDelta);
                             }
                         }
@@ -95,7 +95,7 @@ Following scripting hook removes all assignments from disabled users. Please not
             if (administrativeStatus == ActivationStatusType.DISABLED) {
 				changed = false;
                 for (AssignmentType assign : user.getAssignment()) {
-                    assignmentDelta = ContainerDelta.createModificationDelete(UserType.F_ASSIGNMENT, UserType.class, prismContext, assign.clone());
+                    assignmentDelta = prismContext.deltaFactory().container().createModificationAdd(UserType.F_ASSIGNMENT, UserType.class, assign.clone());
                     log.debug('Removing assignment ' + assignmentDelta + ' from disabled user ' + user.getName());
                     modelContext.getFocusContext().swallowToSecondaryDelta(assignmentDelta);
 					changed = true;


### PR DESCRIPTION
After applying code snippet in the doc, got error below:

`com.evolveum.midpoint.util.exception.ExpressionEvaluationException: Evaluation of hook 'Remove assignments from disabled users' failed: Groovy Evaluation Failed: No signature of method: static com.evolveum.midpoint.prism.delta.ContainerDelta.createModificationDelete() is applicable for argument types: (com.evolveum.midpoint.prism.path.ItemName, Class, com.evolveum.midpoint.prism.impl.PrismContextImpl...) values: [assignment, class com.evolveum.midpoint.xml.ns._public.common.common_3.UserType, ...]
	at com.evolveum.midpoint.model.impl.lens.ClockworkHookHelper.invokeHooks(ClockworkHookHelper.java:107)
	at com.evolveum.midpoint.model.impl.lens.ClockworkClick.moveStateForward(ClockworkClick.java:204)
	at com.evolveum.midpoint.model.impl.lens.ClockworkClick.click(ClockworkClick.java:118)
	at com.evolveum.midpoint.model.impl.lens.Clockwork.click(Clockwork.java:382)
	at com.evolveum.midpoint.model.impl.lens.Clockwork.runWithConflictDetection(Clockwork.java:150)
	at com.evolveum.midpoint.model.impl.lens.Clockwork.run(Clockwork.java:104)
	at com.evolveum.midpoint.model.impl.controller.ModelController.executeChangesNonRaw(ModelController.java:444)
	at com.evolveum.midpoint.model.impl.controller.ModelController.executeChanges(ModelController.java:405)
	at com.evolveum.midpoint.gui.impl.page.admin.ProgressAwareChangesExecutorImpl$1.callWithContextPrepared(ProgressAwareChangesExecutorImpl.java:148)
	at com.evolveum.midpoint.gui.impl.page.admin.ProgressAwareChangesExecutorImpl$1.callWithContextPrepared(ProgressAwareChangesExecutorImpl.java:133)
	at com.evolveum.midpoint.web.component.SecurityContextAwareCallable.call(SecurityContextAwareCallable.java:50)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)`

Fix: changed call of a createModificationDelete as a method of instance ReferenceDeltaFactoryImpl.
