### PR TITLE
Fix LDAP Bundle version for 4.8.1

### DIFF
--- a/midpoint/release/4.8.1/index.adoc
+++ b/midpoint/release/4.8.1/index.adoc
@@ -225,7 +225,7 @@ Note that this resulted in migration from Java EE `javax` package names to `jaka
 
 * New version (2.7) of xref:/connectors/connectors/com.evolveum.polygon.connector.csv.CsvConnector/[CSV Connector] was released and bundled with midPoint. The connector suggest all names of columns for configuration properties related with name of column.
 
-* New version (3.7) of LDAP connector bundle (including xref:/connectors/connectors/com.evolveum.polygon.connector.ldap.LdapConnector/[LDAP Connector] and xref:/connectors/connectors/com.evolveum.polygon.connector.ldap.ad.AdLdapConnector/[Active Directory Connector]) was released and bundled with midPoint.
+* New version (3.7.1) of LDAP connector bundle (including xref:/connectors/connectors/com.evolveum.polygon.connector.ldap.LdapConnector/[LDAP Connector] and xref:/connectors/connectors/com.evolveum.polygon.connector.ldap.ad.AdLdapConnector/[Active Directory Connector]) was released and bundled with midPoint.
 ** This version improve processing of fetching existing entry when updating it in AD connector. (bug:MID-8929[]).
 ** Adding configuration option for suppression of user parameter exceptions and log only a warning message.
 
@@ -459,7 +459,7 @@ We reserve the right not to support customized web browsers.
 | ConnId Connector Framework
 
 | xref:/connectors/connectors/com.evolveum.polygon.connector.ldap.LdapConnector/[LDAP connector bundle]
-| 3.7
+| 3.7.1
 | LDAP and Active Directory
 
 | xref:/connectors/connectors/com.evolveum.polygon.connector.csv.CsvConnector/[CSV connector]


### PR DESCRIPTION
The LDAP Connectors Bundle has version 3.7.1 and no longer 3.7