### PR TITLE
Declare versions ending with zero explicitly as strings

### DIFF
--- a/_data/midpoint-features.yml
+++ b/_data/midpoint-features.yml
@@ -244,7 +244,7 @@
       MidPoint contains a pre-configured dashboard, which provides overview of basic compliance metrics, based on pre-configured policies and policy rules.
       The dashboard can be further extended and customized.
   igaFunctions: [ 'dashboard', 'policy-concept', 'policy-rule' ]
-  since: 4.10
+  since: "4.10"
 
 - id: connid-framework
   title: ConnId identity connector framework
@@ -596,7 +596,7 @@
   related: [ 'assignment', 'abstract-role', 'archetype', 'policy-rule' ]
   igaFunctions: [ 'compliance-management' ]
   status: planned
-  since: 4.10
+  since: "4.10"
 
 - id: linked-objects
   title: Linked objects
@@ -1158,7 +1158,7 @@
   related: [ 'assignment', 'entitlement', 'information-classification', 'rbac' ]
   igaFunctions: [ 'risk-assessment' ]
   status: planned
-  since: 4.10
+  since: "4.10"
 
 - id: role-autoassignment
   title: Role autoassignment


### PR DESCRIPTION
fix  version `4.10` rendering as `4.1`. The version needs to be explicitly declared as string by using quotes