### PR TITLE
Change obsolete xrefv path to current xref

### DIFF
--- a/midpoint/release/4.3.1/index.adoc
+++ b/midpoint/release/4.3.1/index.adoc
@@ -82,7 +82,7 @@ Release {release-version} is a thirty-sixth midPoint release. It is a first main
 
 ** Storing more operation errors in the objects
 
-** xrefv:/midpoint/reference/before-4.8/tasks/task-error-handling/[Retries of failed synchronization operations] (experimental)
+** xref:/midpoint/reference/tasks/activities/error-handling/[Retries of failed synchronization operations] (experimental)
 
 ** Improved handling of multi-node task status
 

--- a/midpoint/release/4.3.2/index.adoc
+++ b/midpoint/release/4.3.2/index.adoc
@@ -84,7 +84,7 @@ Release {release-version} is a thirty-ninth midPoint release. It is a second mai
 
 ** Storing more operation errors in the objects
 
-** xrefv:/midpoint/reference/before-4.8/tasks/task-error-handling/[Retries of failed synchronization operations] (experimental)
+** xref:/midpoint/reference/tasks/activities/error-handling/[Retries of failed synchronization operations] (experimental)
 
 ** Improved handling of multi-node task status
 

--- a/midpoint/release/4.3/index.adoc
+++ b/midpoint/release/4.3/index.adoc
@@ -80,7 +80,7 @@ Release {release-version} is a thirty-fifth midPoint release code-named _Faraday
 
 ** Storing more operation errors in the objects
 
-** xrefv:/midpoint/reference/before-4.8/tasks/task-error-handling/[Retries of failed synchronization operations] (experimental)
+** xref:/midpoint/reference/tasks/activities/error-handling/[Retries of failed synchronization operations] (experimental)
 
 ** Improved handling of multi-node task status
 


### PR DESCRIPTION
This helps to avoid false positive errors during compilation by Jekyll on localhost